### PR TITLE
Add pvc

### DIFF
--- a/src/clickhouse/Dockerfile
+++ b/src/clickhouse/Dockerfile
@@ -103,7 +103,7 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 EXPOSE 9000 8123 9009
-VOLUME /var/lib/clickhouse
+VOLUME /var/lib/clickhouse /data
 
 ENV CLICKHOUSE_CONFIG /etc/clickhouse-server/config.xml
 

--- a/src/clickhouse/manifests/clickhouse-pv.yml
+++ b/src/clickhouse/manifests/clickhouse-pv.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: clickhouse-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: "/data"

--- a/src/clickhouse/manifests/clickhouse-pvc.yml
+++ b/src/clickhouse/manifests/clickhouse-pvc.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: clickhouse-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: standard

--- a/src/clickhouse/manifests/statefulset.yml
+++ b/src/clickhouse/manifests/statefulset.yml
@@ -1,33 +1,29 @@
-#apiVersion: apps/v1
-#kind: StatefulSet
-#metadata:
-#  name: clickhouse
-#spec:
-#  serviceName: "not-applicable"
-#  selector:
-#    matchLabels:
-#      app: clickhouse
-#  template:
-#    metadata:
-#      labels:
-#        app: clickhouse
-#    spec:
-#      containers:
-#        - name: clickhouse
-#          image: slowsunday/fulljoin-clickhouse:latest
-#          ports:
-#            - name: http
-#              protocol: TCP
-#              containerPort: 8123
-#          envFrom:
-#            - configMapRef:
-#                name: clickhouse-configmap
-#            - secretRef:
-#                name: clickhouse-secret
-#          volumeMounts:
-#            - mountPath: "/var/lib/clickhouse"
-#              name: clickhouse-volume
-#      volumes:
-#        - name: clickhouse-volume
-#          persistentVolumeClaim:
-#            claimName: clickhouse-vol
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse
+spec:
+  serviceName: "not-applicable"
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      containers:
+        - name: clickhouse
+          image: slowsunday/fulljoin-clickhouse:latest
+          envFrom:
+            - configMapRef:
+                name: clickhouse-configmap
+            - secretRef:
+                name: clickhouse-secret
+          volumeMounts:
+            - mountPath: "/var/lib/clickhouse"
+              name: clickhouse-volume
+      volumes:
+        - name: clickhouse-volume
+          persistentVolumeClaim:
+            claimName: clickhouse-pvc

--- a/src/dbt/manifests/configmap.yml
+++ b/src/dbt/manifests/configmap.yml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: dbt-configmap
 data:
-  CLICKHOUSE_SVC_ADDRESS: "clickhouse:8123"
+  CLICKHOUSE_SVC_ADDRESS: "clickhouse"

--- a/src/dbt/manifests/dbt-pv.yml
+++ b/src/dbt/manifests/dbt-pv.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: dbt-pv
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: "/dbt"

--- a/src/dbt/manifests/dbt-pvc.yml
+++ b/src/dbt/manifests/dbt-pvc.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbt-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: standard

--- a/src/dbt/manifests/statefulset.yml
+++ b/src/dbt/manifests/statefulset.yml
@@ -1,33 +1,29 @@
-#apiVersion: apps/v1
-#kind: StatefulSet
-#metadata:
-#  name: clickhouse
-#spec:
-#  serviceName: "not-applicable"
-#  selector:
-#    matchLabels:
-#      app: clickhouse
-#  template:
-#    metadata:
-#      labels:
-#        app: clickhouse
-#    spec:
-#      containers:
-#        - name: clickhouse
-#          image: slowsunday/fulljoin-clickhouse:latest
-#          ports:
-#            - name: http
-#              protocol: TCP
-#              containerPort: 8123
-#          envFrom:
-#            - configMapRef:
-#                name: clickhouse-configmap
-#            - secretRef:
-#                name: clickhouse-secret
-#          volumeMounts:
-#            - mountPath: "/var/lib/clickhouse"
-#              name: clickhouse-volume
-#      volumes:
-#        - name: clickhouse-volume
-#          persistentVolumeClaim:
-#            claimName: clickhouse-vol
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dbt
+spec:
+  serviceName: "not-applicable"
+  selector:
+    matchLabels:
+      app: dbt
+  template:
+    metadata:
+      labels:
+        app: dbt
+    spec:
+      containers:
+        - name: dbt
+          image: slowsunday/fulljoin:latest
+          envFrom:
+            - configMapRef:
+                name: dbt-configmap
+            - secretRef:
+                name: dbt-secret
+          volumeMounts:
+            - mountPath: "/dbt"
+              name: dbt-volume
+      volumes:
+        - name: dbt-volume
+          persistentVolumeClaim:
+            claimName: dbt-pvc


### PR DESCRIPTION
adding persistent volume.
There is an issue, clickhouse saves data in /var/lib/clickhouse. However, when we run "minikube stop" that data is gone. Some data is pertained in /data directory that is mounted as a volume. Need to figure out how to work around this.

another issue, when a person will build an image, the volume will not get transfered. That would involve copying the build inside docker, or use a paid storage provider to mount volume there.